### PR TITLE
Update argument for starting Prometheus node exporter

### DIFF
--- a/ansible/roles/prometheus/templates/prometheus-haproxy-exporter.json.j2
+++ b/ansible/roles/prometheus/templates/prometheus-haproxy-exporter.json.j2
@@ -1,5 +1,5 @@
 {
-    "command": "/opt/haproxy_exporter/haproxy_exporter -haproxy.scrape-uri unix:/var/lib/kolla/haproxy/haproxy.sock -web.listen-address {{ api_interface_address }}:{{ prometheus_haproxy_exporter_port }}",
+    "command": "/opt/haproxy_exporter/haproxy_exporter --haproxy.scrape-uri unix:/var/lib/kolla/haproxy/haproxy.sock --web.listen-address {{ api_interface_address }}:{{ prometheus_haproxy_exporter_port }}",
     "config_files": [],
     "permissions": [
         {

--- a/ansible/roles/prometheus/templates/prometheus-mysqld-exporter.json.j2
+++ b/ansible/roles/prometheus/templates/prometheus-mysqld-exporter.json.j2
@@ -1,5 +1,5 @@
 {
-    "command": "/opt/mysqld_exporter/mysqld_exporter -config.my-cnf /etc/prometheus/my.cnf -web.listen-address {{ api_interface_address }}:{{ prometheus_mysqld_exporter_port }}",
+    "command": "/opt/mysqld_exporter/mysqld_exporter --config.my-cnf /etc/prometheus/my.cnf --web.listen-address {{ api_interface_address }}:{{ prometheus_mysqld_exporter_port }}",
     "config_files": [
         {
             "source": "{{ container_config_directory }}/my.cnf",

--- a/ansible/roles/prometheus/templates/prometheus-node-exporter.json.j2
+++ b/ansible/roles/prometheus/templates/prometheus-node-exporter.json.j2
@@ -1,5 +1,5 @@
 {
-    "command": "/opt/node_exporter/node_exporter -collector.procfs /host/proc -collector.sysfs /host/sys -web.listen-address {{ api_interface_address }}:{{ prometheus_node_exporter_port }}",
+    "command": "/opt/node_exporter/node_exporter --path.procfs /host/proc --path.sysfs /host/sys --web.listen-address {{ api_interface_address }}:{{ prometheus_node_exporter_port }}",
     "config_files": [],
     "permissions": [
         {


### PR DESCRIPTION
This will probably be superseded by a patch from Michal Nasiadka
but if it isn't it can go upstream as part of the Prometheus service
version upgrade.

Ref for one of the breaking changes:

https://github.com/prometheus/node_exporter/commit/3cf5b006fb22068c8c72b0e7acabc1ae988560d3