### PR TITLE
Default to Prometheus tag for all Prometheus images

### DIFF
--- a/ansible/roles/prometheus/defaults/main.yml
+++ b/ansible/roles/prometheus/defaults/main.yml
@@ -116,11 +116,11 @@ prometheus_memcached_exporter_tag: "{{ prometheus_tag }}"
 prometheus_memcached_exporter_image_full: "{{ prometheus_memcached_exporter_image }}:{{ prometheus_memcached_exporter_tag }}"
 
 prometheus_cadvisor_image: "{{ docker_registry ~ '/' if docker_registry else '' }}{{ docker_namespace }}/{{ kolla_base_distro }}-{{ kolla_install_type }}-prometheus-cadvisor"
-prometheus_cadvisor_tag: "{{ openstack_release }}"
+prometheus_cadvisor_tag: "{{ prometheus_tag }}"
 prometheus_cadvisor_image_full: "{{ prometheus_cadvisor_image }}:{{ prometheus_cadvisor_tag }}"
 
 prometheus_alertmanager_image: "{{ docker_registry ~ '/' if docker_registry else '' }}{{ docker_namespace }}/{{ kolla_base_distro }}-{{ kolla_install_type }}-prometheus-alertmanager"
-prometheus_alertmanager_tag: "{{ openstack_release }}"
+prometheus_alertmanager_tag: "{{ prometheus_tag }}"
 prometheus_alertmanager_image_full: "{{ prometheus_alertmanager_image }}:{{ prometheus_alertmanager_tag }}"
 
 prometheus_server_dimensions: "{{ default_container_dimensions }}"


### PR DESCRIPTION
This allows an operator to pin the Prometheus docker image
tag for all Prometheus images to that specified by the `prometheus_tag`.
Without this change, the alert manager and cadvisor tags would also need
to be set.

Change-Id: Iadef001af7d3be5b2a39ce5e2363d05a33a775e4