### PR TITLE
Don't set recurse on config folders

### DIFF
--- a/ansible/roles/common/tasks/config.yml
+++ b/ansible/roles/common/tasks/config.yml
@@ -16,7 +16,6 @@
   file:
     path: "{{ node_config_directory }}/{{ item }}"
     state: "directory"
-    recurse: yes
   become: true
   with_items:
     - "fluentd"

--- a/ansible/roles/heat/tasks/config.yml
+++ b/ansible/roles/heat/tasks/config.yml
@@ -7,7 +7,6 @@
     owner: "{{ config_owner_user }}"
     group: "{{ config_owner_group }}"
     mode: "0770"
-    recurse: yes
   when:
     - inventory_hostname in groups[item.value.group]
     - item.value.enabled | bool

--- a/ansible/roles/kafka/tasks/config.yml
+++ b/ansible/roles/kafka/tasks/config.yml
@@ -6,7 +6,6 @@
     owner: "{{ config_owner_user }}"
     group: "{{ config_owner_group }}"
     mode: "0770"
-    recurse: yes
   become: true
   when:
     - inventory_hostname in groups[item.value.group]

--- a/ansible/roles/monasca/tasks/config.yml
+++ b/ansible/roles/monasca/tasks/config.yml
@@ -6,7 +6,6 @@
     owner: "{{ config_owner_user }}"
     group: "{{ config_owner_group }}"
     mode: "0770"
-    recurse: yes
   become: true
   when:
     - inventory_hostname in groups[item.value.group]

--- a/ansible/roles/zookeeper/tasks/config.yml
+++ b/ansible/roles/zookeeper/tasks/config.yml
@@ -6,7 +6,6 @@
     owner: "{{ config_owner_user }}"
     group: "{{ config_owner_group }}"
     mode: "0770"
-    recurse: yes
   become: true
   when:
     - inventory_hostname in groups[item.value.group]


### PR DESCRIPTION
A small number of services set the recurse flag when they create
their config directory. This can change permission of files within
the directory, which are later set back to the original state. The
side effect is that the service is then restarted, even though the
net change to the config files amounts to nothing. The expected
behaviour is that a service only restarts if the config *has*
changed. This patch fixes this issue.

Change-Id: Ib6f1ca7b416247f8d455fb25892f4a3b27de03ba
Closes-Bug: 1800480

Conflicts:
	ansible/roles/storm/tasks/config.yml