### PR TITLE
Add support for deploying Jiralert

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -292,6 +292,7 @@ prometheus_ceph_mgr_exporter_port: "9283"
 prometheus_cadvisor_port: "18080"
 prometheus_mtail_port: "9197"
 prometheus_libvirt_exporter_port: "9177"
+prometheus_jiralert_port: "9097"
 
 # Prometheus alertmanager ports
 prometheus_alertmanager_port: "9093"
@@ -554,6 +555,7 @@ num_nova_fake_per_node: 5
 # Monitoring options are specified here
 enable_collectd: "no"
 enable_prometheus: "no"
+enable_prometheus_jiralert: "no"
 
 # Clean images options are specified here
 enable_destroy_images: "no"
@@ -876,6 +878,12 @@ enable_prometheus_mtail: "{{ enable_prometheus | bool }}"
 enable_prometheus_elasticsearch_exporter: "{{ enable_prometheus | bool and enable_elasticsearch | bool }}"
 enable_prometheus_libvirt_exporter: "{{ enable_prometheus | bool and enable_nova | bool }}"
 enable_prometheus_ceph_mgr_exporter: "{{ enable_ceph | bool and enable_prometheus | bool }}"
+
+# Prometheus Jiralert settings
+enable_prometheus_jiralert: "no"
+prometheus_jiralert_api_url:
+prometheus_jiralert_user:
+prometheus_jiralert_project:
 
 prometheus_alertmanager_user: "admin"
 prometheus_openstack_exporter_interval: "60s"

--- a/ansible/inventory/all-in-one
+++ b/ansible/inventory/all-in-one
@@ -717,3 +717,6 @@ elasticsearch
 
 [prometheus-libvirt-exporter:children]
 compute
+
+[prometheus-jiralert:children]
+prometheus-alertmanager

--- a/ansible/inventory/multinode
+++ b/ansible/inventory/multinode
@@ -736,3 +736,6 @@ elasticsearch
 
 [prometheus-libvirt-exporter:children]
 compute
+
+[prometheus-jiralert:children]
+prometheus-alertmanager

--- a/ansible/roles/prometheus/defaults/main.yml
+++ b/ansible/roles/prometheus/defaults/main.yml
@@ -126,6 +126,16 @@ prometheus_services:
       - "/etc/localtime:/etc/localtime:ro"
       - "libvirtd_run:/var/run/libvirt:ro"
     dimensions: "{{ prometheus_libvirt_exporter_dimensions }}"
+  prometheus-jiralert:
+    container_name: "prometheus_jiralert"
+    group: "prometheus-jiralert"
+    enabled: "{{ enable_prometheus_jiralert | bool }}"
+    image: "{{ prometheus_jiralert_image_full }}"
+    volumes:
+      - "{{ node_config_directory }}/prometheus-jiralert/:{{ container_config_directory }}/:ro"
+      - "/etc/localtime:/etc/localtime:ro"
+      - "kolla_logs:/var/log/kolla/"
+    dimensions: "{{ prometheus_jiralert_dimensions }}"
 
 ####################
 # Database
@@ -139,6 +149,11 @@ prometheus_mtail_log_directories:
   - /var/log/secure
   - /var/log/messages
   - /var/log/kolla/keystone/*.log #Need some way of only configuring on host running keyston
+
+###################
+# Jiralert
+###################
+prometheus_jiralert_default_receiver_name: 'jira'
 
 ####################
 # Docker
@@ -191,6 +206,10 @@ prometheus_libvirt_exporter_image: "{{ docker_registry ~ '/' if docker_registry 
 prometheus_libvirt_exporter_tag: "{{ prometheus_tag }}"
 prometheus_libvirt_exporter_image_full: "{{ prometheus_libvirt_exporter_image }}:{{ prometheus_libvirt_exporter_tag }}"
 
+prometheus_jiralert_image: "{{ docker_registry ~ '/' if docker_registry else '' }}{{ docker_namespace }}/{{ kolla_base_distro }}-{{ kolla_install_type }}-prometheus-jiralert"
+prometheus_jiralert_tag: "{{ prometheus_tag }}"
+prometheus_jiralert_image_full: "{{ prometheus_jiralert_image }}:{{ prometheus_jiralert_tag }}"
+
 prometheus_server_dimensions: "{{ default_container_dimensions }}"
 prometheus_haproxy_exporter_dimensions: "{{ default_container_dimensions }}"
 prometheus_mysqld_exporter_dimensions: "{{ default_container_dimensions }}"
@@ -202,3 +221,4 @@ prometheus_openstack_exporter_dimensions: "{{ default_container_dimensions }}"
 prometheus_mtail_dimensions: "{{ default_container_dimensions }}"
 prometheus_elasticsearch_exporter_dimensions: "{{ default_container_dimensions }}"
 prometheus_libvirt_exporter_dimensions: "{{ default_container_dimensions }}"
+prometheus_jiralert_dimensions: "{{ default_container_dimensions }}"

--- a/ansible/roles/prometheus/handlers/main.yml
+++ b/ansible/roles/prometheus/handlers/main.yml
@@ -233,3 +233,26 @@
     - service.enabled | bool
     - config_json.changed | bool
       or prometheus_container.changed | bool
+
+- name: Restart prometheus-jiralert container
+  vars:
+    service_name: "prometheus-jiralert"
+    service: "{{ prometheus_services[service_name] }}"
+    config_json: "{{ prometheus_config_jsons.results|selectattr('item.key', 'equalto', service_name)|first }}"
+    prometheus_container: "{{ check_prometheus_containers.results|selectattr('item.key', 'equalto', service_name)|first }}"
+  become: true
+  kolla_docker:
+    action: "recreate_or_restart_container"
+    common_options: "{{ docker_common_options }}"
+    name: "{{ service.container_name }}"
+    image: "{{ service.image }}"
+    volumes: "{{ service.volumes }}"
+    dimensions: "{{ service.dimensions }}"
+  when:
+    - kolla_action != "config"
+    - inventory_hostname in groups[service.group]
+    - service.enabled | bool
+    - config_json.changed | bool
+      or prometheus_jiralert_confs.changed | bool
+      or prometheus_jiralert_template.changed | bool
+      or prometheus_container.changed | bool

--- a/ansible/roles/prometheus/tasks/config.yml
+++ b/ansible/roles/prometheus/tasks/config.yml
@@ -178,6 +178,42 @@
   notify:
     - Restart prometheus-mtail container
 
+- name: Copying over prometheus jiralert config file
+  vars:
+    service: "{{ prometheus_services['prometheus-jiralert']}}"
+  template:
+    src: "{{ item }}"
+    dest: "{{ node_config_directory }}/prometheus-jiralert/jiralert.yml"
+  become: true
+  register: prometheus_jiralert_confs
+  when:
+    - inventory_hostname in groups[service.group]
+    - service.enabled | bool
+  with_first_found:
+    - "{{ node_custom_config }}/prometheus/{{ inventory_hostname }}/prometheus-jiralert.yml"
+    - "{{ node_custom_config }}/prometheus/prometheus-jiralert.yml"
+    - "{{ role_path }}/templates/prometheus-jiralert.yml.j2"
+  notify:
+    - Restart prometheus-jiralert container
+
+- name: Copying over prometheus jiralert template file
+  vars:
+    service: "{{ prometheus_services['prometheus-jiralert']}}"
+  copy:
+    src: "{{ item }}"
+    dest: "{{ node_config_directory }}/prometheus-jiralert/jiralert.tmpl"
+  become: true
+  register: prometheus_jiralert_template
+  when:
+    - inventory_hostname in groups[service.group]
+    - service.enabled | bool
+  with_first_found:
+    - "{{ node_custom_config }}/prometheus/{{ inventory_hostname }}/prometheus-jiralert.tmpl"
+    - "{{ node_custom_config }}/prometheus/prometheus-jiralert.tmpl"
+    - "{{ role_path }}/templates/prometheus-jiralert.tmpl"
+  notify:
+    - Restart prometheus-jiralert container
+
 - name: Check prometheus containers
   become: true
   kolla_docker:

--- a/ansible/roles/prometheus/tasks/precheck.yml
+++ b/ansible/roles/prometheus/tasks/precheck.yml
@@ -13,6 +13,7 @@
       - prometheus_mtail
       - prometheus_elasticsearch_exporter
       - prometheus_libvirt_exporter
+      - prometheus_jiralert
   register: container_facts
 
 - name: Checking free port for Prometheus server
@@ -156,3 +157,17 @@
     - enable_prometheus_libvirt_exporter | bool
   with_items:
     - "{{ prometheus_libvirt_exporter_port }}"
+
+- name: Checking free ports for Prometheus Jiralert
+  wait_for:
+    host: "{{ hostvars[inventory_hostname]['ansible_' + api_interface]['ipv4']['address'] }}"
+    port: "{{ item }}"
+    connect_timeout: 1
+    timeout: 1
+    state: stopped
+  when:
+    - container_facts['prometheus_jiralert'] is not defined
+    - inventory_hostname in groups['prometheus-jiralert']
+    - enable_prometheus_jiralert | bool
+  with_items:
+    - "{{ prometheus_jiralert_port }}"

--- a/ansible/roles/prometheus/templates/prometheus-alertmanager.yml.j2
+++ b/ansible/roles/prometheus/templates/prometheus-alertmanager.yml.j2
@@ -8,4 +8,9 @@ route:
   repeat_interval: 3h
 receivers:
   - name: default-receiver
+{% if prometheus_enable_jira | bool %}
+  - name: 'jira'
+    webhook_configs:
+    - url: 'http://localhost:9097/alert'
+{% endif %}
 templates: []

--- a/ansible/roles/prometheus/templates/prometheus-jiralert.json.j2
+++ b/ansible/roles/prometheus/templates/prometheus-jiralert.json.j2
@@ -1,0 +1,24 @@
+{
+    "command": "/opt/jiralert/jiralert -config /etc/jiralert/jiralert.yml -listen-address :9097 -log_dir /var/log/kolla/prometheus -alsologtostderr false",
+    "config_files": [
+        {
+            "source": "{{ container_config_directory }}/jiralert.yml",
+            "dest": "/etc/jiralert/jiralert.yml",
+            "owner": "prometheus",
+            "perm": "0600"
+        },
+        {
+            "source": "{{ container_config_directory }}/jiralert.tmpl",
+            "dest": "/etc/jiralert/jiralert.tmpl",
+            "owner": "prometheus",
+            "perm": "0600"
+        }
+    ],
+    "permissions": [
+        {
+            "path": "/var/log/kolla/prometheus",
+            "owner": "prometheus:kolla",
+            "recurse": true
+        }
+    ]
+}

--- a/ansible/roles/prometheus/templates/prometheus-jiralert.tmpl
+++ b/ansible/roles/prometheus/templates/prometheus-jiralert.tmpl
@@ -1,0 +1,10 @@
+{{ define "jira.summary" }}[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .GroupLabels.SortedPairs.Values | join " " }} {{ if gt (len .CommonLabels) (len .GroupLabels) }}({{ with .CommonLabels.Remove .GroupLabels.Names }}{{ .Values | join " " }}{{ end }}){{ end }}{{ end }}
+
+{{ define "jira.description" }}{{ range .Alerts.Firing }}Labels:
+{{ range .Labels.SortedPairs }} - {{ .Name }} = {{ .Value }}
+{{ end }}
+Annotations:
+{{ range .Annotations.SortedPairs }} - {{ .Name }} = {{ .Value }}
+{{ end }}
+Source: {{ .GeneratorURL }}
+{{ end }}{{ end }}

--- a/ansible/roles/prometheus/templates/prometheus-jiralert.yml.j2
+++ b/ansible/roles/prometheus/templates/prometheus-jiralert.yml.j2
@@ -1,0 +1,17 @@
+defaults:
+  api_url: '{{ prometheus_jiralert_api_url }}'
+  user: '{{ prometheus_jiralert_user }}'
+  password: '{{ prometheus_jiralert_api_token }}'
+  issue_type: Bug
+{% raw %}
+  summary: '{{ template "jira.summary" . }}'
+  description: '{{ template "jira.description" . }}'
+{% endraw %}
+  reopen_state: "To Do"
+  wont_fix_resolution: "Won't Fix"
+  reopen_duration: 0h
+receivers:
+  - name: '{{ prometheus_jiralert_default_receiver_name }}'
+    project: '{{ prometheus_jiralert_project }}'
+    add_group_labels: true
+template: jiralert.tmpl

--- a/etc/kolla/globals.yml
+++ b/etc/kolla/globals.yml
@@ -509,3 +509,4 @@ tempest_floating_network_name:
 #enable_prometheus_elasticsearch_exporter: "{{ enable_prometheus | bool and enable_elasticsearch | bool }}"
 #enable_prometheus_libvirt_exporter: "{{ enable_prometheus | bool and enable_nova | bool }}"
 #enable_prometheus_ceph_mgr_exporter: "{{ enable_prometheus | bool and enable_ceph | bool }}"
+#enable_prometheus_jiralert: "{{ enable_prometheus | bool and enable_prometheus_jiralert | bool }}"

--- a/etc/kolla/passwords.yml
+++ b/etc/kolla/passwords.yml
@@ -259,6 +259,7 @@ xenserver_password:
 ####################
 prometheus_mysql_exporter_database_password:
 prometheus_alertmanager_password:
+prometheus_jiralert_api_token:
 
 ############
 # Onos

--- a/releasenotes/notes/add-prometheus-jiraalert-296c26816bfc8e61.yaml
+++ b/releasenotes/notes/add-prometheus-jiraalert-296c26816bfc8e61.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Jiralert is a service which runs alongside Prometheus Alertmanger to
+    generate Jira tickets from alerts. It provides the glue between
+    the Prometheus Alertmanger webhook notification service and Jira. See
+    https://github.com/free/jiralert for more details.


### PR DESCRIPTION
Jiralert is a service which runs alongside Prometheus Alertmanger to
generate Jira tickets from alerts. It provides the glue between
the Prometheus Alertmanger webhook notification service and Jira. See
https://github.com/free/jiralert for more details.