### PR TITLE
Add emit_unmatched_lines to fluentd config

### DIFF
--- a/ansible/roles/common/templates/conf/input/00-global.conf.j2
+++ b/ansible/roles/common/templates/conf/input/00-global.conf.j2
@@ -54,4 +54,5 @@
   time_format %F %T.%L
   ignore_repeated_permission_error true
   enable_watch_timer false
+  emit_unmatched_lines true
 </source>

--- a/ansible/roles/common/templates/conf/input/02-mariadb.conf.j2
+++ b/ansible/roles/common/templates/conf/input/02-mariadb.conf.j2
@@ -9,4 +9,5 @@
   format1 /^(?<time>\d{6} \d{1,2}:\d{1,2}:\d{1,2}) (\[(?<log_level>\S+)\]|mysqld_safe) (?<Payload>.*)/
   time_format %y%m%d %k:%M:%S
   enable_watch_timer false
+  emit_unmatched_lines true
 </source>

--- a/ansible/roles/common/templates/conf/input/03-rabbitmq.conf.j2
+++ b/ansible/roles/common/templates/conf/input/03-rabbitmq.conf.j2
@@ -9,4 +9,5 @@
   format1 /^=(?<log_level>\w+) REPORT==== (?<Times>[^ ]+) ===\n/
   format2 /^(?<Payload>.*)/
   enable_watch_timer false
+  emit_unmatched_lines true
 </source>

--- a/ansible/roles/common/templates/conf/input/04-openstack-wsgi.conf.j2
+++ b/ansible/roles/common/templates/conf/input/04-openstack-wsgi.conf.j2
@@ -7,4 +7,5 @@
   tag kolla.*
   format /^(?<Payload>.*)$/
   enable_watch_timer false
+  emit_unmatched_lines true
 </source>

--- a/ansible/roles/common/templates/conf/input/05-libvirt.conf.j2
+++ b/ansible/roles/common/templates/conf/input/05-libvirt.conf.j2
@@ -8,4 +8,5 @@
   time_key Timestamp
   time_format %F %T.%L%z
   enable_watch_timer false
+  emit_unmatched_lines true
 </source>

--- a/ansible/roles/common/templates/conf/input/06-zookeeper.conf.j2
+++ b/ansible/roles/common/templates/conf/input/06-zookeeper.conf.j2
@@ -8,4 +8,5 @@
   format_firstline /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3} \S+ \S+ \S+ .*$/
   format1 /^(?<Timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}) \[(?<server_id>\S+)\] \S+ (?<log_level>\S+) (?<Payload>.*)$/
   time_key Timestamp
+  emit_unmatched_lines true
 </source>

--- a/ansible/roles/common/templates/conf/input/07-kafka.conf.j2
+++ b/ansible/roles/common/templates/conf/input/07-kafka.conf.j2
@@ -8,4 +8,5 @@
   format_firstline /^\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}\] \S+ .*$/
   format1 /^\[(?<Timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3})\] (?<log_level>\S+) (?<Payload>.*)$/
   time_key Timestamp
+  emit_unmatched_lines true
 </source>

--- a/ansible/roles/common/templates/conf/input/08-opendaylight.conf.j2
+++ b/ansible/roles/common/templates/conf/input/08-opendaylight.conf.j2
@@ -8,4 +8,5 @@
   format_firstline /\d{4}-\d{2}-\d{2}/
   format1 /^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\,\d{3})\s+\|\s+(?<level>[^|\s]+)\s+\|\s+(?<thread>[^|]+)\s+\|\s+(?<class>[\d -}]+)\s+\|\s+(?<bundle>[^|]+)\s+\|\s+(?<msg>.*)/
   time_format %Y-%m-%d %H:%M:%S,%L
+  emit_unmatched_lines true
 </source>

--- a/ansible/roles/common/templates/conf/input/09-caso.conf.j2
+++ b/ansible/roles/common/templates/conf/input/09-caso.conf.j2
@@ -4,4 +4,5 @@
   port {{ caso_tcp_output_port }}
   bind 127.0.0.1
   format /^(?<Payload>.*)$/
+  emit_unmatched_lines true
 </source>


### PR DESCRIPTION
When you fail to match one of the grok filters in the tail input,
the log is just dropped today. Ideally we capture it so we can
fix the failed to match lines. Sadly it is often infrequent error
messages that get dropped.