### PR TITLE
Ironic serial console patches

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -261,6 +261,7 @@ nova_metadata_port: "8775"
 nova_novncproxy_port: "6080"
 nova_spicehtml5proxy_port: "6082"
 nova_serialproxy_port: "6083"
+nova_serialproxy_protocol: "{{ 'wss' if kolla_enable_tls_external | bool else 'ws' }}"
 
 octavia_api_port: "9876"
 octavia_health_manager_port: "5555"

--- a/ansible/roles/ironic/templates/ironic.conf.j2
+++ b/ansible/roles/ironic/templates/ironic.conf.j2
@@ -19,6 +19,8 @@ transport_url = {{ rpc_transport_url }}
 pin_release_version = {{ pin_release_version }}
 {% endif %}
 
+my_ip = {{ api_interface_address }}
+
 [oslo_messaging_notifications]
 transport_url = {{ notify_transport_url }}
 

--- a/ansible/roles/nova/templates/nova.conf.j2
+++ b/ansible/roles/nova/templates/nova.conf.j2
@@ -103,7 +103,7 @@ enabled = false
 {% if enable_nova_serialconsole_proxy | bool %}
 [serial_console]
 enabled = true
-base_url = ws://{{ kolla_external_fqdn }}:{{ nova_serialproxy_port }}/
+base_url = {{ nova_serialproxy_protocol }}://{{ nova_serialproxy_fqdn }}:{{ nova_serialproxy_port }}/
 serialproxy_host = {{ api_interface_address }}
 serialproxy_port = {{ nova_serialproxy_port }}
 proxyclient_address = {{ api_interface_address }}


### PR DESCRIPTION
Backporting patches from upstream, to enable Ironic serial console access 

Use secure websockets when TLS is in use on the Overcloud external network
https://review.opendev.org/#/c/679222

Explicitly set Ironic IP, to prevent socat listener binding to an unintended interface
https://review.opendev.org/679215
