### PR TITLE
Use <project>_install_type instead of kolla_install_type

### DIFF
--- a/ansible/roles/aodh/templates/wsgi-aodh.conf.j2
+++ b/ansible/roles/aodh/templates/wsgi-aodh.conf.j2
@@ -1,5 +1,5 @@
-{% set python_path = '/usr/lib/python2.7/site-packages' if kolla_install_type == 'binary' else '/var/lib/kolla/venv/lib/python2.7/site-packages' %}
-{% set binary_path = '/usr/bin' if kolla_install_type == 'binary' else '/var/lib/kolla/venv/bin' %}
+{% set python_path = '/usr/lib/python2.7/site-packages' if aodh_install_type == 'binary' else '/var/lib/kolla/venv/lib/python2.7/site-packages' %}
+{% set binary_path = '/usr/bin' if aodh_install_type == 'binary' else '/var/lib/kolla/venv/bin' %}
 Listen {{ api_interface_address }}:{{ aodh_api_port }}
 
 ServerSignature Off

--- a/ansible/roles/cinder/templates/cinder-wsgi.conf.j2
+++ b/ansible/roles/cinder/templates/cinder-wsgi.conf.j2
@@ -1,4 +1,4 @@
-{% set python_path = '/usr/lib/python2.7/site-packages' if kolla_install_type == 'binary' else '/var/lib/kolla/venv/lib/python2.7/site-packages' %}
+{% set python_path = '/usr/lib/python2.7/site-packages' if cinder_install_type == 'binary' else '/var/lib/kolla/venv/lib/python2.7/site-packages' %}
 Listen {{ api_interface_address }}:{{ cinder_api_port }}
 
 ServerSignature Off

--- a/ansible/roles/cloudkitty/templates/wsgi-cloudkitty.conf.j2
+++ b/ansible/roles/cloudkitty/templates/wsgi-cloudkitty.conf.j2
@@ -1,5 +1,5 @@
-{% set python_path = '/usr/lib/python2.7/site-packages' if kolla_install_type == 'binary' else '/var/lib/kolla/venv/lib/python2.7/site-packages' %}
-{% set binary_path = '/usr/bin' if kolla_install_type == 'binary' else '/var/lib/kolla/venv/bin' %}
+{% set python_path = '/usr/lib/python2.7/site-packages' if cloudkitty_install_type == 'binary' else '/var/lib/kolla/venv/lib/python2.7/site-packages' %}
+{% set binary_path = '/usr/bin' if cloudkitty_install_type == 'binary' else '/var/lib/kolla/venv/bin' %}
 Listen {{ api_interface_address }}:{{ cloudkitty_api_port }}
 
 ServerSignature Off

--- a/ansible/roles/freezer/templates/wsgi-freezer-api.conf.j2
+++ b/ansible/roles/freezer/templates/wsgi-freezer-api.conf.j2
@@ -1,5 +1,5 @@
 {% set freezer_log_dir = '/var/log/kolla/freezer' %}
-{% set python_path = '/usr/lib/python2.7/site-packages' if kolla_install_type == 'binary' else '/var/lib/kolla/venv/lib/python2.7/site-packages' %}
+{% set python_path = '/usr/lib/python2.7/site-packages' if freezer_install_type == 'binary' else '/var/lib/kolla/venv/lib/python2.7/site-packages' %}
 Listen {{ api_interface_address }}:{{ freezer_api_port }}
 
 ServerSignature Off

--- a/ansible/roles/gnocchi/templates/wsgi-gnocchi.conf.j2
+++ b/ansible/roles/gnocchi/templates/wsgi-gnocchi.conf.j2
@@ -1,5 +1,9 @@
-{% set python_path = '/usr/lib/python2.7/site-packages' if kolla_install_type == 'binary' else '/var/lib/kolla/venv/lib/python2.7/site-packages' %}
-{% set wsgi_path = '/usr/bin' if kolla_install_type == 'binary' else '/var/lib/kolla/venv/bin' %}
+{% if gnocchi_install_type == 'binary' %}
+    {% set python_path = '/usr/lib/python3/dist-packages' if kolla_base_distro == 'ubuntu' else '/usr/lib/python2.7/site-packages' %}
+{% else %}
+    {% set python_path = '/var/lib/kolla/venv/lib/python2.7/site-packages' %}
+{% endif %}
+{% set wsgi_path = '/usr/bin' if gnocchi_install_type == 'binary' else '/var/lib/kolla/venv/bin' %}
 Listen {{ api_interface_address }}:{{ gnocchi_api_port }}
 
 ServerSignature Off

--- a/ansible/roles/horizon/defaults/main.yml
+++ b/ansible/roles/horizon/defaults/main.yml
@@ -56,7 +56,8 @@ horizon_database_address: "{{ database_address }}:{{ database_port }}"
 ####################
 # Docker
 ####################
-horizon_image: "{{ docker_registry ~ '/' if docker_registry else '' }}{{ docker_namespace }}/{{ kolla_base_distro }}-{{ kolla_install_type }}-horizon"
+horizon_install_type: "{{ kolla_install_type }}"
+horizon_image: "{{ docker_registry ~ '/' if docker_registry else '' }}{{ docker_namespace }}/{{ kolla_base_distro }}-{{ horizon_install_type }}-horizon"
 horizon_tag: "{{ openstack_release }}"
 horizon_image_full: "{{ horizon_image }}:{{ horizon_tag }}"
 

--- a/ansible/roles/horizon/templates/horizon.conf.j2
+++ b/ansible/roles/horizon/templates/horizon.conf.j2
@@ -1,4 +1,4 @@
-{% set python_path = '/usr/share/openstack-dashboard' if kolla_install_type == 'binary' else '/var/lib/kolla/venv/lib/python2.7/site-packages' %}
+{% set python_path = '/usr/share/openstack-dashboard' if horizon_install_type == 'binary' else '/var/lib/kolla/venv/lib/python2.7/site-packages' %}
 Listen {{ api_interface_address }}:{{ horizon_port }}
 
 ServerSignature Off
@@ -22,7 +22,7 @@ TraceEnable off
         Require all granted
     </Location>
 
-{% if kolla_base_distro == 'ubuntu' and kolla_install_type == 'binary' %}
+{% if kolla_base_distro == 'ubuntu' and horizon_install_type == 'binary' %}
     Alias /static /var/lib/openstack-dashboard/static
 {% else %}
     Alias /static {{ python_path }}/static

--- a/ansible/roles/keystone/templates/wsgi-keystone.conf.j2
+++ b/ansible/roles/keystone/templates/wsgi-keystone.conf.j2
@@ -1,6 +1,6 @@
 {% set keystone_log_dir = '/var/log/kolla/keystone' %}
-{% set python_path = '/usr/lib/python2.7/site-packages' if kolla_install_type == 'binary' else '/var/lib/kolla/venv/lib/python2.7/site-packages' %}
-{% set binary_path = '/usr/bin' if kolla_install_type == 'binary' else '/var/lib/kolla/venv/bin' %}
+{% set python_path = '/usr/lib/python2.7/site-packages' if keystone_install_type == 'binary' else '/var/lib/kolla/venv/lib/python2.7/site-packages' %}
+{% set binary_path = '/usr/bin' if keystone_install_type == 'binary' else '/var/lib/kolla/venv/bin' %}
 Listen {{ api_interface_address }}:{{ keystone_public_port }}
 Listen {{ api_interface_address }}:{{ keystone_admin_port }}
 

--- a/ansible/roles/monasca/templates/monasca-api/wsgi-api.conf.j2
+++ b/ansible/roles/monasca/templates/monasca-api/wsgi-api.conf.j2
@@ -1,4 +1,4 @@
-{% set python_path = '/usr/lib/python2.7/site-packages' if kolla_install_type == 'binary' else '/var/lib/kolla/venv/lib/python2.7/site-packages' %}
+{% set python_path = '/usr/lib/python2.7/site-packages' if monasca_install_type == 'binary' else '/var/lib/kolla/venv/lib/python2.7/site-packages' %}
 {% set wsgi_path = '/usr/bin' if monasca_install_type == 'binary' else '/monasca-api/monasca_api/api' %}
 
 Listen {{ api_interface_address }}:{{ monasca_api_port }}

--- a/ansible/roles/monasca/templates/monasca-log-api/wsgi-log-api.conf.j2
+++ b/ansible/roles/monasca/templates/monasca-log-api/wsgi-log-api.conf.j2
@@ -1,4 +1,4 @@
-{% set python_path = '/usr/lib/python2.7/site-packages' if kolla_install_type == 'binary' else '/var/lib/kolla/venv/lib/python2.7/site-packages' %}
+{% set python_path = '/usr/lib/python2.7/site-packages' if monasca_install_type == 'binary' else '/var/lib/kolla/venv/lib/python2.7/site-packages' %}
 {% set wsgi_path = '/usr/bin' if monasca_install_type == 'binary' else '/monasca-log/monasca_log_api/app' %}
 
 Listen {{ api_interface_address }}:{{ monasca_log_api_port }}

--- a/ansible/roles/nova/templates/placement-api-wsgi.conf.j2
+++ b/ansible/roles/nova/templates/placement-api-wsgi.conf.j2
@@ -1,6 +1,6 @@
 {% set log_dir = '/var/log/kolla/nova' %}
-{% set python_path = '/usr/lib/python2.7/site-packages' if kolla_install_type == 'binary' else '/var/lib/kolla/venv/lib/python2.7/site-packages' %}
-{% set wsgi_directory = '/usr/bin' if kolla_install_type == 'binary' else '/var/lib/kolla/venv/bin' %}
+{% set python_path = '/usr/lib/python2.7/site-packages' if nova_install_type == 'binary' else '/var/lib/kolla/venv/lib/python2.7/site-packages' %}
+{% set wsgi_directory = '/usr/bin' if nova_install_type == 'binary' else '/var/lib/kolla/venv/bin' %}
 Listen {{ api_interface_address }}:{{ placement_api_port }}
 
 ServerSignature Off

--- a/ansible/roles/panko/defaults/main.yml
+++ b/ansible/roles/panko/defaults/main.yml
@@ -26,7 +26,8 @@ panko_database_mysql_address: "{{ database_address }}:{{ database_port }}"
 ####################
 # Docker
 ####################
-panko_api_image: "{{ docker_registry ~ '/' if docker_registry else '' }}{{ docker_namespace }}/{{ kolla_base_distro }}-{{ kolla_install_type }}-panko-api"
+panko_install_type: "{{ kolla_install_type }}"
+panko_api_image: "{{ docker_registry ~ '/' if docker_registry else '' }}{{ docker_namespace }}/{{ kolla_base_distro }}-{{ panko_install_type }}-panko-api"
 panko_api_tag: "{{ openstack_release }}"
 panko_api_image_full: "{{ panko_api_image }}:{{ panko_api_tag }}"
 panko_api_dimensions: "{{ default_container_dimensions }}"

--- a/ansible/roles/panko/templates/wsgi-panko.conf.j2
+++ b/ansible/roles/panko/templates/wsgi-panko.conf.j2
@@ -1,5 +1,5 @@
-{% set python_path = '/usr/lib/python2.7/site-packages' if kolla_install_type == 'binary' else '/var/lib/kolla/venv/lib/python2.7/site-packages' %}
-{% set binary_path = '/usr/bin' if kolla_install_type == 'binary' else '/var/lib/kolla/venv/bin' %}
+{% set python_path = '/usr/lib/python2.7/site-packages' if panko_install_type == 'binary' else '/var/lib/kolla/venv/lib/python2.7/site-packages' %}
+{% set binary_path = '/usr/bin' if panko_install_type == 'binary' else '/var/lib/kolla/venv/bin' %}
 Listen {{ api_interface_address }}:{{ panko_api_port }}
 
 ServerSignature Off

--- a/ansible/roles/vitrage/templates/wsgi-vitrage.conf.j2
+++ b/ansible/roles/vitrage/templates/wsgi-vitrage.conf.j2
@@ -1,4 +1,4 @@
-{% set python_path = '/usr/lib/python2.7/site-packages' if kolla_install_type == 'binary' else '/var/lib/kolla/venv/lib/python2.7/site-packages' %}
+{% set python_path = '/usr/lib/python2.7/site-packages' if vitrage_install_type == 'binary' else '/var/lib/kolla/venv/lib/python2.7/site-packages' %}
 Listen {{ hostvars[inventory_hostname]['ansible_' + api_interface]['ipv4']['address'] }}:{{ vitrage_api_port }}
 
 ServerSignature Off

--- a/ansible/roles/vmtp/defaults/main.yml
+++ b/ansible/roles/vmtp/defaults/main.yml
@@ -15,7 +15,8 @@ vmtp_services:
 ####################
 # Docker
 ####################
-vmtp_image: "{{ docker_registry ~ '/' if docker_registry else '' }}{{ docker_namespace }}/{{ kolla_base_distro }}-{{ kolla_install_type }}-vmtp"
+vmtp_install_type: "{{ kolla_install_type }}"
+vmtp_image: "{{ docker_registry ~ '/' if docker_registry else '' }}{{ docker_namespace }}/{{ kolla_base_distro }}-{{ vmtp_install_type }}-vmtp"
 vmtp_tag: "{{ openstack_release }}"
 vmtp_image_full: "{{ vmtp_image }}:{{ vmtp_tag }}"
 vmtp_dimensions: "{{ default_container_dimensions }}"

--- a/ansible/roles/vmtp/tasks/config.yml
+++ b/ansible/roles/vmtp/tasks/config.yml
@@ -15,12 +15,12 @@
 - name: Register binary python path
   command: echo /usr/lib/python2.7/site-packages
   register: python_path
-  when: kolla_install_type == 'binary'
+  when: vmtp_install_type == 'binary'
 
 - name: Register source python path
   command: echo /var/lib/kolla/venv/lib/python2.7/site-packages
   register: python_path
-  when: kolla_install_type != 'binary'
+  when: vmtp_install_type != 'binary'
 
 - name: Copying over configuration file for vmtp
   vars:

--- a/ansible/roles/zun/templates/wsgi-zun.conf.j2
+++ b/ansible/roles/zun/templates/wsgi-zun.conf.j2
@@ -1,4 +1,4 @@
-{% set python_path = '/usr/lib/python2.7/site-packages' if kolla_install_type == 'binary' else '/var/lib/kolla/venv/lib/python2.7/site-packages' %}
+{% set python_path = '/usr/lib/python2.7/site-packages' if zun_install_type == 'binary' else '/var/lib/kolla/venv/lib/python2.7/site-packages' %}
 Listen {{ api_interface_address }}:{{ zun_api_port }}
 
 ServerSignature Off


### PR DESCRIPTION
Use <project>_install_type instead of kolla_install_type
to set python_path. For example, general kolla_install_type
is 'binary', but user wants to deploy Horizon from 'source'.
Horizon templates still use python_path=/usr/share/openstack-dashboard,
it is wrong.

Conflicts:
	ansible/roles/gnocchi/templates/wsgi-gnocchi.conf.j2

Change-Id: Ide6a24e17b1f8ab6506aa5e53f70693706830418
Closes-Bug: #1854735
(cherry picked from commit 043943117d2e10d787da1db7e87cd69852fc6cd2)
(cherry picked from commit 8d12907be88695ace365ad5d08333b160e3614f8)