### PR TITLE
Replace regex failing to match recent Docker versions, 

### DIFF
--- a/ansible/roles/prechecks/tasks/service_checks.yml
+++ b/ansible/roles/prechecks/tasks/service_checks.yml
@@ -6,7 +6,7 @@
   changed_when: false
   when: inventory_hostname in groups['baremetal']
   failed_when: result is failed
-               or result.stdout | regex_replace('.*(\\d+\\.\\d+\\.\\d+).*', '\\1')  is version(docker_version_min, '<')
+               or result.stdout | regex_replace('.*?(\\d+\\.\\d+\\.\\d+).*?', '\\1') is version(docker_version_min, '<')
 
 # NOTE(mgoddard): If passwords.yml is encrypted using ansible-vault, this check
 # will pass, but only because nothing in the vault file has the format of a


### PR DESCRIPTION
Replace regex failing to match recent Docker versions, by using 'non-greedy' modifier