### PR TITLE
Make it possible to override automatic fluentd version detection

### DIFF
--- a/ansible/roles/common/tasks/config.yml
+++ b/ansible/roles/common/tasks/config.yml
@@ -33,7 +33,9 @@
     action: "ensure_image"
     common_options: "{{ docker_common_options }}"
     image: "{{ service.image }}"
-  when: enable_fluentd | bool
+  when:
+    - fluentd_version is not defined or fluentd_binary is not defined
+    - enable_fluentd | bool
 
 - name: Fetch fluentd image labels
   vars:
@@ -43,12 +45,16 @@
   docker_image_facts:
     name: "{{ service.image }}"
   register: fluentd_labels
-  when: enable_fluentd | bool
+  when:
+     - fluentd_version is not defined or fluentd_binary is not defined
+     - enable_fluentd | bool
 
 - name: Set fluentd facts
   set_fact:
     fluentd_binary: "{% if fluentd_labels.images.0.ContainerConfig.Labels.fluentd_binary is not defined %}{% if kolla_base_distro in 'ubuntu' and ansible_architecture == 'x86_64' %}td-agent{% else %}fluentd{% endif %}{% else %}{{ fluentd_labels.images.0.ContainerConfig.Labels.fluentd_binary }}{% endif %}"
-  when: enable_fluentd | bool
+  when:
+     - fluentd_binary is not defined
+     - enable_fluentd | bool
 
 - name: Copying over config.json files for services
   template:

--- a/releasenotes/notes/optional-fluentd-version-detection-3cb8b8a8ebc02d0a.yaml
+++ b/releasenotes/notes/optional-fluentd-version-detection-3cb8b8a8ebc02d0a.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Adds the ability to override the automatic detection of `fluentd_version`
+    and `fluentd_binary`. These can now be defined as extra variables. This
+    removes the dependency of having docker configured for config generation.


### PR DESCRIPTION
One use case for this is so that you can generate config in a CI job
without access to the container repository. It also removes the
dependency of having docker configured for config generation.

TrivialFix

Change-Id: I0d388851c8b953af0494e44ae569e7eb9e15c326
(cherry picked from commit fab9abd1ea89a2b564e8aa69afbce76910dc88ce)