### PR TITLE
Add override timeout for openstack exporter

### DIFF
--- a/ansible/action_plugins/merge_yaml.py
+++ b/ansible/action_plugins/merge_yaml.py
@@ -30,6 +30,7 @@ except ImportError:
 
 
 from ansible import constants
+from ansible import errors as ansible_errors
 from ansible.plugins import action
 import six
 
@@ -51,6 +52,20 @@ options:
     default: None
     required: True
     type: str
+  extend_lists:
+    description:
+      - For a given key referencing a list, this determines whether
+        the list items should be combined with the items in another
+        document if an equivalent key is found. An equivalent key
+        has the same parents and value as the first. The default
+        behaviour is to replace existing entries i.e if you have
+        two yaml documents that both define a list with an equivalent
+        key, the value from the document that appears later in the
+        list of sources will replace the value that appeared in the
+        earlier one.
+    default: False
+    required: False
+    type: bool
 author: Sean Mooney
 '''
 
@@ -108,10 +123,12 @@ class ActionModule(action.ActionBase):
 
         output = {}
         sources = self._task.args.get('sources', None)
+        extend_lists = self._task.args.get('extend_lists', False)
         if not isinstance(sources, list):
             sources = [sources]
         for source in sources:
-            Utils.update_nested_conf(output, self.read_config(source))
+            Utils.update_nested_conf(
+                output, self.read_config(source), extend_lists)
 
         # restore original vars
         self._templar.set_available_variables(old_vars)
@@ -125,7 +142,7 @@ class ActionModule(action.ActionBase):
 
             new_task = self._task.copy()
             new_task.args.pop('sources', None)
-
+            new_task.args.pop('extend_lists', None)
             new_task.args.update(
                 dict(
                     src=result_file
@@ -148,10 +165,22 @@ class ActionModule(action.ActionBase):
 
 class Utils(object):
     @staticmethod
-    def update_nested_conf(conf, update):
+    def update_nested_conf(conf, update, extend_lists=False):
         for k, v in six.iteritems(update):
             if isinstance(v, dict):
-                conf[k] = Utils.update_nested_conf(conf.get(k, {}), v)
+                conf[k] = Utils.update_nested_conf(
+                    conf.get(k, {}), v, extend_lists)
+            elif k in conf and isinstance(conf[k], list) and extend_lists:
+                if not isinstance(v, list):
+                    errmsg = (
+                        "Failure merging key `%(key)s` in dictionary "
+                        "`%(dictionary)s`. Expecting a list, but received: "
+                        "`%(value)s`, which is of type: `%(type)s`" % {
+                            "key": k, "dictionary": conf,
+                            "value": v, "type": type(v)}
+                    )
+                    raise ansible_errors.AnsibleModuleError(errmsg)
+                conf[k].extend(v)
             else:
                 conf[k] = v
         return conf

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -1135,6 +1135,7 @@ prometheus_jiralert_project:
 
 prometheus_alertmanager_user: "admin"
 prometheus_openstack_exporter_interval: "60s"
+prometheus_openstack_exporter_timeout: "10s"
 prometheus_elasticsearch_exporter_interval: "60s"
 prometheus_cmdline_extras:
 prometheus_mtail_interval: "10s"

--- a/ansible/roles/prometheus/tasks/config.yml
+++ b/ansible/roles/prometheus/tasks/config.yml
@@ -52,14 +52,27 @@
   notify:
     - Restart prometheus-server container
 
+- name: Find prometheus config overrides
+  find:
+    # NOTE(wszumski): Non-existent paths don't produce a failure
+    paths:
+      - "{{ node_custom_config }}/prometheus/prometheus.yml.d"
+      - "{{ node_custom_config }}/prometheus/{{ inventory_hostname }}/prometheus.yml.d"
+    patterns: "*.yml"
+  delegate_to: localhost
+  register: prometheus_config_overrides_result
+  run_once: true
+
 - name: Copying over prometheus config file
   become: true
   vars:
-    service: "{{ prometheus_services['prometheus-server']}}"
-  template:
-    src: "{{ item }}"
+    service: "{{ prometheus_services['prometheus-server'] }}"
+    overrides: "{{ prometheus_config_overrides_result.files | map(attribute='path') | list }}"
+  merge_yaml:
+    sources: "{{ [prometheus_config_file] + overrides }}"
     dest: "{{ node_config_directory }}/prometheus-server/prometheus.yml"
     mode: "0660"
+    extend_lists: true
   when:
     - inventory_hostname in groups[service.group]
     - service.enabled | bool

--- a/ansible/roles/prometheus/templates/prometheus.yml.j2
+++ b/ansible/roles/prometheus/templates/prometheus.yml.j2
@@ -78,6 +78,7 @@ scrape_configs:
 {% if enable_prometheus_openstack_exporter | bool %}
   - job_name: openstack_exporter
     scrape_interval: {{ prometheus_openstack_exporter_interval }}
+    scrape_timeout: {{ prometheus_openstack_exporter_timeout }}
     honor_labels: true
     static_configs:
       - targets:

--- a/doc/source/reference/logging-and-monitoring/prometheus-guide.rst
+++ b/doc/source/reference/logging-and-monitoring/prometheus-guide.rst
@@ -30,3 +30,39 @@ and data retention period to 2 days:
 .. code-block:: yaml
 
    prometheus_cmdline_extras: "-storage.remote.timeout 30s -storage.local.retention 48h"
+
+Extending prometheus.cfg
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you want to add extra targets to scrape, you can extend the default
+``prometheus.yml`` config file by placing additional configs in
+``{{ node_custom_config }}/prometheus/prometheus.yml.d``. These should have the
+same format as ``prometheus.yml``. These additional configs are merged so
+that any list items are extended. For example, if using the default value for
+``node_custom_config``, you could add additional targets to scape by defining
+``/etc/kolla/config/prometheus/prometheus.yml.d/10-custom.yml`` containing the
+following:
+
+.. code-block:: jinja
+
+  scrape_configs:
+    - job_name: custom
+      static_configs:
+        - targets:
+          - '10.0.0.111:1234'
+    - job_name: custom-template
+      static_configs:
+        - targets:
+  {% for host in groups['prometheus'] %}
+          - '{{ hostvars[host]['ansible_' + hostvars[host]['api_interface']]['ipv4']['address'] }}:{{ 3456 }}'
+  {% endfor %}
+
+The jobs, ``custom``, and ``custom_template``  would be appended to the default
+list of ``scrape_configs`` in the final ``prometheus.yml``. To customize on a per
+host basis, files can also be placed in
+``{{ node_custom_config }}/prometheus/<inventory_hostname>/prometheus.yml.d``
+where, ``inventory_hostname`` is one of the hosts in your inventory. These
+will be merged with any files in ``{{ node_custom_config }}/prometheus/prometheus.yml.d``,
+so in order to override a list value instead of extending it, you will need to make
+sure that no files in ``{{ node_custom_config }}/prometheus/prometheus.yml.d``
+set a key with an equivalent hierarchical path.

--- a/releasenotes/notes/add-mechanism-for-prometheus-customization-0b173ff7c63ca30f.yaml
+++ b/releasenotes/notes/add-mechanism-for-prometheus-customization-0b173ff7c63ca30f.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Added a mechanism to customize ``prometheus.yml``. Please read the the
+    `documentation <https://docs.openstack.org/kolla-ansible/latest/reference/logging-and-monitoring/prometheus-guide.html>`__.
+    for more details.

--- a/releasenotes/notes/add-openstack-exporter-scrape-timeout-af5dcd5d988ae12b.yaml
+++ b/releasenotes/notes/add-openstack-exporter-scrape-timeout-af5dcd5d988ae12b.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - Add new option prometheus_openstack_exporter_timeout to override default
+    scrape_timeout for openstack exporter job.


### PR DESCRIPTION
Add scrape_timeout option in
prometheus_openstack_exporter job in order
to avoid timeout for large Openstack environment.

Change-Id: If96034e602bee3b3eea34a2656047355e1d17eec
Closes-Bug: #1903547