### PR TITLE
Add support for custom grafana dashboards

### DIFF
--- a/ansible/roles/grafana/tasks/config.yml
+++ b/ansible/roles/grafana/tasks/config.yml
@@ -94,3 +94,71 @@
     - "prometheus.yaml.j2"
   notify:
     - Restart grafana container
+
+- name: Configuring dashboards provisioning
+  vars:
+    service: "{{ grafana_services['grafana'] }}"
+  template:
+    src: "{{ item }}"
+    dest: "{{ node_config_directory }}/grafana/provisioning.yaml"
+    mode: "0660"
+  become: true
+  when:
+    - inventory_hostname in groups[service.group]
+    - service.enabled | bool
+  with_first_found:
+    - "{{ node_custom_config }}/grafana/{{ inventory_hostname }}/provisioning.yaml"
+    - "{{ node_custom_config }}/grafana/provisioning.yaml"
+    - "{{ role_path }}/templates/provisioning.yaml.j2"
+  notify:
+    - Restart grafana container
+
+- name: Check if the folder for custom grafana dashboards exists
+  stat:
+    path: "{{ node_custom_config }}/grafana/dashboards"
+  delegate_to: localhost
+  register: grafana_custom_dashboards_folder
+  run_once: True
+
+- name: Remove templated Grafana dashboards
+  become: true
+  vars:
+    service: "{{ grafana_services['grafana'] }}"
+  file:
+    state: absent
+    path: "{{ node_config_directory }}/grafana/dashboards/"
+  when:
+    - inventory_hostname in groups[service.group]
+    - service.enabled | bool
+
+- name: Create custom Grafana dashboards folder
+  become: true
+  vars:
+    service: "{{ grafana_services['grafana'] }}"
+  file:
+    dest: "{{ node_config_directory }}/grafana/dashboards/"
+    state: "directory"
+    mode: "0770"
+  when:
+    - grafana_custom_dashboards_folder.stat.exists
+    - grafana_custom_dashboards_folder.stat.isdir
+    - inventory_hostname in groups[service.group]
+    - service.enabled | bool
+
+- name: Copying over custom dashboards
+  vars:
+    service: "{{ grafana_services['grafana'] }}"
+  copy:
+    src: "{{ item }}"
+    dest: "{{ node_config_directory }}/grafana/dashboards/"
+    mode: "0660"
+  become: true
+  when:
+    - grafana_custom_dashboards_folder.stat.exists
+    - grafana_custom_dashboards_folder.stat.isdir
+    - inventory_hostname in groups[service.group]
+    - service.enabled | bool
+  with_fileglob:
+    - "{{ node_custom_config }}/grafana/dashboards/*.json"
+  notify:
+    - Restart grafana container

--- a/ansible/roles/grafana/templates/grafana.json.j2
+++ b/ansible/roles/grafana/templates/grafana.json.j2
@@ -28,6 +28,19 @@
             "owner": "root",
             "perm": "0644",
             "optional": true
+        },
+        {
+            "source": "{{ container_config_directory }}/provisioning.yaml",
+            "dest": "/etc/grafana/provisioning/dashboards/provisioning.yaml",
+            "owner": "root",
+            "perm": "0644"
+        },
+        {
+            "source": "{{ container_config_directory }}/dashboards/",
+            "dest": "/var/lib/grafana/dashboards",
+            "owner": "grafana",
+            "perm": "0755",
+            "optional": true
         }
     ],
     "permissions": [

--- a/ansible/roles/grafana/templates/provisioning.yaml.j2
+++ b/ansible/roles/grafana/templates/provisioning.yaml.j2
@@ -1,0 +1,11 @@
+# # config file version
+apiVersion: 1
+
+providers:
+ - name: 'default'
+   orgId: 1
+   folder: ''
+   folderUid: ''
+   type: file
+   options:
+     path: /var/lib/grafana/dashboards

--- a/doc/source/reference/logging-and-monitoring/grafana-guide.rst
+++ b/doc/source/reference/logging-and-monitoring/grafana-guide.rst
@@ -1,0 +1,46 @@
+.. _grafana-guide:
+
+=======
+Grafana
+=======
+
+Overview
+~~~~~~~~
+
+`Grafana <https://grafana.com>`_ is open and composable observability and
+data visualization platform. Visualize metrics, logs, and traces from
+multiple sources like Prometheus, Loki, Elasticsearch, InfluxDB,
+Postgres and many more..
+
+Preparation and deployment
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To enable Grafana, modify the configuration file ``/etc/kolla/globals.yml``
+and change the following:
+
+.. code-block:: yaml
+
+   enable_grafana: "yes"
+
+If you would like to set up Prometheus as a data source additionally set:
+
+.. code-block:: yaml
+
+   enable_prometheus: "yes"
+
+Please follow :doc:`Prometheus Guide <prometheus-guide>` for more information
+
+Custom Dashboards Provisioning
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Kolla Ansible sets Custom Dashboards Provisioning using `Dashboard provider <https://grafana.com/docs/grafana/latest/administration/provisioning/#dashboards>`_.
+
+Dashboard's JSON files should be placed into
+``{{ node_custom_config }}/grafana/dashboards/`` folder.
+Dashboards will be imported to Grafana dashboards General Folder.
+
+Grafana provisioner config can be altered by placing ``provisioning.yaml`` to
+``{{ node_custom_config }}/grafana/`` folder.
+
+For other settings follow configuration reference:
+`Dashboard provider configuration <https://grafana.com/docs/grafana/latest/administration/provisioning/#dashboards>`_.

--- a/doc/source/reference/logging-and-monitoring/index.rst
+++ b/doc/source/reference/logging-and-monitoring/index.rst
@@ -9,6 +9,7 @@ logging and monitoring services available in kolla.
    :maxdepth: 1
 
    central-logging-guide
+   grafana-guide
    monasca-guide
    osprofiler-guide
    prometheus-guide

--- a/releasenotes/notes/custom-grafana-dashboards-fd4c8a00cd2dd126.yaml
+++ b/releasenotes/notes/custom-grafana-dashboards-fd4c8a00cd2dd126.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Adds support to import custom ``grafana`` dashboards. Dashboard's JSON
+    files should be placed into "{{ node_custom_config }}/grafana/dashboards/"
+    folder.


### PR DESCRIPTION
Allow users to import custom grafana dashboards.
Dashboards as JSON files should be placed into
"{{ node_custom_config }}/grafana/dashboards/" folder.

Change-Id: Id0f83b8d08541b3b74649f097b10c9450201b426